### PR TITLE
feat: add FF_Modals feature flag and update related tests

### DIFF
--- a/__tests__/app/api/feature-flags/route.test.ts
+++ b/__tests__/app/api/feature-flags/route.test.ts
@@ -5,6 +5,9 @@ jest.mock("@/lib/utils/feature-flags", () => ({
   getFeatureFlags: jest.fn(),
   DEFAULT_FLAGS: {
     enableAuthentication: true,
+    FF_Chat_Analysis_Screen: true,
+    FF_Full_Page_Navigation: true,
+    FF_Modals: true,
   },
 }));
 
@@ -35,6 +38,9 @@ describe("/api/feature-flags", () => {
     // Arrange
     const mockFlags = {
       enableAuthentication: true,
+      FF_Chat_Analysis_Screen: true,
+      FF_Full_Page_Navigation: true,
+      FF_Modals: true,
     };
     
     mockGetFeatureFlags.mockResolvedValue(mockFlags);

--- a/__tests__/components/Modals/FeatureFlaggedDialog.test.tsx
+++ b/__tests__/components/Modals/FeatureFlaggedDialog.test.tsx
@@ -27,7 +27,7 @@ describe("FeatureFlaggedDialog", () => {
       </FeatureFlaggedDialog>
     );
 
-    expect(screen.getByTestId("ui5-dialog")).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="ui5-dialog"]')).toBeInTheDocument();
   });
 
   it("renders fallback when flag disabled and not loading", () => {
@@ -46,7 +46,7 @@ describe("FeatureFlaggedDialog", () => {
       </FeatureFlaggedDialog>
     );
 
-    expect(screen.queryByTestId("ui5-dialog")).not.toBeInTheDocument();
+    expect(document.querySelector('[data-testid="ui5-dialog"]')).not.toBeInTheDocument();
     expect(screen.getByTestId("fallback")).toBeInTheDocument();
   });
 
@@ -59,6 +59,6 @@ describe("FeatureFlaggedDialog", () => {
 
     render(<FeatureFlaggedDialog open>Content</FeatureFlaggedDialog>);
 
-    expect(screen.getByTestId("ui5-dialog")).toBeInTheDocument();
+    expect(document.querySelector('[data-testid="ui5-dialog"]')).toBeInTheDocument();
   });
 });

--- a/__tests__/components/Modals/FeatureFlaggedDialog.test.tsx
+++ b/__tests__/components/Modals/FeatureFlaggedDialog.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import FeatureFlaggedDialog from "@/components/Modals/FeatureFlaggedDialog";
+
+// Mock the hook to control flag state
+jest.mock("@/hooks/useFeatureFlags", () => ({
+  useFeatureFlag: jest.fn(),
+}));
+
+import { useFeatureFlag } from "@/hooks/useFeatureFlags";
+
+describe("FeatureFlaggedDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders Dialog when loading is true (no flicker)", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({
+      flag: false,
+      loading: true,
+      error: null,
+    });
+
+    render(
+      <FeatureFlaggedDialog open header={<div>Header</div>}>
+        Content
+      </FeatureFlaggedDialog>
+    );
+
+    expect(screen.getByTestId("ui5-dialog")).toBeInTheDocument();
+  });
+
+  it("renders fallback when flag disabled and not loading", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({
+      flag: false,
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <FeatureFlaggedDialog
+        open
+        fallback={<div data-testid="fallback">off</div>}
+      >
+        Content
+      </FeatureFlaggedDialog>
+    );
+
+    expect(screen.queryByTestId("ui5-dialog")).not.toBeInTheDocument();
+    expect(screen.getByTestId("fallback")).toBeInTheDocument();
+  });
+
+  it("renders Dialog when flag enabled", () => {
+    (useFeatureFlag as jest.Mock).mockReturnValue({
+      flag: true,
+      loading: false,
+      error: null,
+    });
+
+    render(<FeatureFlaggedDialog open>Content</FeatureFlaggedDialog>);
+
+    expect(screen.getByTestId("ui5-dialog")).toBeInTheDocument();
+  });
+});

--- a/__tests__/hooks/useFeatureFlags.test.ts
+++ b/__tests__/hooks/useFeatureFlags.test.ts
@@ -58,6 +58,7 @@ describe("useFeatureFlags hooks", () => {
         enableAuthentication: true,
         FF_Chat_Analysis_Screen: true,
         FF_Full_Page_Navigation: true,
+        FF_Modals: true,
       });
     });
 
@@ -92,6 +93,7 @@ describe("useFeatureFlags hooks", () => {
         enableAuthentication: true,
         FF_Chat_Analysis_Screen: true,
         FF_Full_Page_Navigation: true,
+        FF_Modals: true,
       });
     });
 

--- a/__tests__/lib/utils/feature-flags-edge.test.ts
+++ b/__tests__/lib/utils/feature-flags-edge.test.ts
@@ -39,6 +39,7 @@ describe("feature-flags-edge", () => {
         enableAuthentication: true, // default is true when env var is not 'false'
         FF_Chat_Analysis_Screen: true, // default is true when env var is not 'false'
         FF_Full_Page_Navigation: true, // default is true when env var is not 'false'
+        FF_Modals: true, // default is true when env var is not 'false'
       });
     });
 
@@ -53,6 +54,7 @@ describe("feature-flags-edge", () => {
         enableAuthentication: false,
         FF_Chat_Analysis_Screen: true,
         FF_Full_Page_Navigation: true,
+        FF_Modals: true,
       });
     });
 
@@ -67,6 +69,7 @@ describe("feature-flags-edge", () => {
         enableAuthentication: true,
         FF_Chat_Analysis_Screen: true,
         FF_Full_Page_Navigation: true,
+        FF_Modals: true,
       });
     });
 
@@ -81,6 +84,7 @@ describe("feature-flags-edge", () => {
         enableAuthentication: true,
         FF_Chat_Analysis_Screen: true,
         FF_Full_Page_Navigation: true,
+        FF_Modals: true,
       });
     });
 
@@ -100,6 +104,7 @@ describe("feature-flags-edge", () => {
         enableAuthentication: true, // DEFAULT_FLAGS value
         FF_Chat_Analysis_Screen: true, // DEFAULT_FLAGS value
         FF_Full_Page_Navigation: true, // DEFAULT_FLAGS value
+        FF_Modals: true, // DEFAULT_FLAGS value
       });
       expect(mockConsoleWarn).toHaveBeenCalledWith(
         "Error loading feature flags in edge runtime, using defaults:",

--- a/__tests__/lib/utils/feature-flags-edge.test.ts
+++ b/__tests__/lib/utils/feature-flags-edge.test.ts
@@ -32,6 +32,7 @@ describe("feature-flags-edge", () => {
       delete process.env.ENABLE_AUTHENTICATION;
       delete process.env.FF_Chat_Analysis_Screen;
       delete process.env.FF_Full_Page_Navigation;
+      delete process.env.FF_Modals;
 
       const result = loadFeatureFlagsEdge();
 
@@ -47,7 +48,7 @@ describe("feature-flags-edge", () => {
       process.env.ENABLE_AUTHENTICATION = "false";
       delete process.env.FF_Chat_Analysis_Screen;
       delete process.env.FF_Full_Page_Navigation;
-
+      delete process.env.FF_Modals;
       const result = loadFeatureFlagsEdge();
 
       expect(result).toEqual({
@@ -62,7 +63,7 @@ describe("feature-flags-edge", () => {
       process.env.ENABLE_AUTHENTICATION = "true";
       delete process.env.FF_Chat_Analysis_Screen;
       delete process.env.FF_Full_Page_Navigation;
-
+      delete process.env.FF_Modals;
       const result = loadFeatureFlagsEdge();
 
       expect(result).toEqual({
@@ -77,7 +78,7 @@ describe("feature-flags-edge", () => {
       process.env.ENABLE_AUTHENTICATION = "yes";
       delete process.env.FF_Chat_Analysis_Screen;
       delete process.env.FF_Full_Page_Navigation;
-
+      delete process.env.FF_Modals;
       const result = loadFeatureFlagsEdge();
 
       expect(result).toEqual({
@@ -124,7 +125,7 @@ describe("feature-flags-edge", () => {
     it('should return true for enableAuthentication when flag is present and env var is not "false"', () => {
       delete process.env.ENABLE_AUTHENTICATION;
       delete process.env.FF_Chat_Analysis_Screen;
-
+      delete process.env.FF_Modals;
       const result = isFeatureEnabledEdge("enableAuthentication");
 
       expect(result).toBe(true);
@@ -133,7 +134,7 @@ describe("feature-flags-edge", () => {
     it('should return false for enableAuthentication when env var is "false"', () => {
       process.env.ENABLE_AUTHENTICATION = "false";
       delete process.env.FF_Chat_Analysis_Screen;
-
+      delete process.env.FF_Modals;
       const result = isFeatureEnabledEdge("enableAuthentication");
 
       expect(result).toBe(false);
@@ -206,7 +207,7 @@ describe("feature-flags-edge", () => {
       // Test the FF_Chat_Analysis_Screen flag to ensure it works correctly
       delete process.env.ENABLE_AUTHENTICATION;
       delete process.env.FF_Chat_Analysis_Screen;
-
+      delete process.env.FF_Modals; 
       let result = isFeatureEnabledEdge("FF_Chat_Analysis_Screen");
       expect(result).toBe(true);
 
@@ -266,7 +267,7 @@ describe("feature-flags-edge", () => {
       // Test with an unknown flag key to ensure the nullish coalescing works
       delete process.env.ENABLE_AUTHENTICATION;
       delete process.env.FF_Chat_Analysis_Screen;
-
+      delete process.env.FF_Modals;
       // This should return undefined for the flag, then fallback to DEFAULT_FLAGS
       // Since DEFAULT_FLAGS doesn't have 'unknownFlag', it should return undefined
       const result = isFeatureEnabledEdge(

--- a/feature-flags.example.json
+++ b/feature-flags.example.json
@@ -1,5 +1,6 @@
 {
   "enableAuthentication": true,
   "FF_Chat_Analysis_Screen": true,
-  "FF_Full_Page_Navigation": true
+  "FF_Full_Page_Navigation": true,
+  "FF_Modals": true
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -68,6 +68,20 @@ global.fetch = jest.fn((url) => {
     });
   }
 
+  // Mock feature flags API with defaults used in tests
+  if (url.toString().includes("/api/feature-flags")) {
+    return Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          enableAuthentication: true,
+          FF_Chat_Analysis_Screen: true,
+          FF_Full_Page_Navigation: true,
+          FF_Modals: true,
+        }),
+    });
+  }
+
   return Promise.resolve({
     ok: true,
     json: () => Promise.resolve({}),

--- a/scripts/generate-feature-flags.js
+++ b/scripts/generate-feature-flags.js
@@ -18,6 +18,7 @@ const DEFAULT_FLAGS = {
   enableAuthentication: true,
   FF_Chat_Analysis_Screen: true,
   FF_Full_Page_Navigation: true,
+  FF_Modals: true,
 };
 
 // Helper function for handling environment variables

--- a/src/components/Modals/ConfirmationModal.tsx
+++ b/src/components/Modals/ConfirmationModal.tsx
@@ -5,11 +5,11 @@ import {
   FlexBoxAlignItems,
   Text,
   Icon,
-  Dialog,
   Button,
   Title,
   FlexBoxDirection,
 } from "@ui5/webcomponents-react";
+import FeatureFlaggedDialog from "@/components/Modals/FeatureFlaggedDialog";
 
 interface ModalAction {
   label: string;
@@ -42,7 +42,7 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   description,
 }) => {
   return (
-    <Dialog
+    <FeatureFlaggedDialog
       open={isOpen}
       onClose={onClose}
       aria-labelledby="modal-title"
@@ -127,6 +127,6 @@ export const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
           </Text>
         )}
       </FlexBox>
-    </Dialog>
+    </FeatureFlaggedDialog>
   );
 };

--- a/src/components/Modals/ConfirmationModal.tsx
+++ b/src/components/Modals/ConfirmationModal.tsx
@@ -9,7 +9,7 @@ import {
   Title,
   FlexBoxDirection,
 } from "@ui5/webcomponents-react";
-import FeatureFlaggedDialog from "@/components/Modals/FeatureFlaggedDialog";
+import { FeatureFlaggedDialog } from "@/components/Modals/FeatureFlaggedDialog";
 
 interface ModalAction {
   label: string;

--- a/src/components/Modals/FeatureFlaggedDialog.tsx
+++ b/src/components/Modals/FeatureFlaggedDialog.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React from "react";
+import { Dialog, type DialogPropTypes, type DialogDomRef } from "@ui5/webcomponents-react";
+import { useFeatureFlag } from "@/hooks/useFeatureFlags";
+
+type FeatureFlaggedDialogProps = DialogPropTypes & {
+  fallback?: React.ReactNode;
+};
+
+export const FeatureFlaggedDialog = React.forwardRef<DialogDomRef, FeatureFlaggedDialogProps>(
+  function FeatureFlaggedDialog(props, ref) {
+    const { fallback = null, ...dialogProps } = props;
+    const { flag: enabled, loading } = useFeatureFlag("FF_Modals");
+
+    // While loading flags, render the dialog to avoid layout flicker and keep previous behavior
+    if (loading) {
+      return <Dialog ref={ref} {...dialogProps} />;
+    }
+
+    if (!enabled) {
+      return <>{fallback}</>;
+    }
+
+    return <Dialog ref={ref} {...dialogProps} />;
+  }
+);
+
+export default FeatureFlaggedDialog;
+
+

--- a/src/components/Modals/RawDataModal.tsx
+++ b/src/components/Modals/RawDataModal.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { Button, Dialog, FlexBox } from "@ui5/webcomponents-react";
+import { Button, FlexBox } from "@ui5/webcomponents-react";
 import type { DialogPropTypes, DialogDomRef } from "@ui5/webcomponents-react";
 import BaseDataTable from "@/components/Tables/BaseDataTable";
 import { tableData } from "@/lib/constants/mocks/dataTable";
 import { twMerge } from "tailwind-merge";
+import FeatureFlaggedDialog from "@/components/Modals/FeatureFlaggedDialog";
 
 type RawDataDialogProps = DialogPropTypes & {
   data: {
@@ -20,7 +21,7 @@ export const RawDataModal = (props: RawDataDialogProps) => {
   };
 
   return (
-    <Dialog
+    <FeatureFlaggedDialog
       ref={dialogRef}
       {...props}
       header={
@@ -53,6 +54,6 @@ export const RawDataModal = (props: RawDataDialogProps) => {
           </Button>
         </FlexBox>
       </div>
-    </Dialog>
+    </FeatureFlaggedDialog>
   );
 };

--- a/src/components/Modals/RawDataModal.tsx
+++ b/src/components/Modals/RawDataModal.tsx
@@ -4,7 +4,7 @@ import type { DialogPropTypes, DialogDomRef } from "@ui5/webcomponents-react";
 import BaseDataTable from "@/components/Tables/BaseDataTable";
 import { tableData } from "@/lib/constants/mocks/dataTable";
 import { twMerge } from "tailwind-merge";
-import FeatureFlaggedDialog from "@/components/Modals/FeatureFlaggedDialog";
+import { FeatureFlaggedDialog } from "@/components/Modals/FeatureFlaggedDialog";
 
 type RawDataDialogProps = DialogPropTypes & {
   data: {

--- a/src/lib/types/feature-flags.ts
+++ b/src/lib/types/feature-flags.ts
@@ -2,6 +2,7 @@ export interface FeatureFlags {
   enableAuthentication: boolean;
   FF_Chat_Analysis_Screen: boolean;
   FF_Full_Page_Navigation: boolean;
+  FF_Modals: boolean;
 }
 
 export type FeatureFlagKey = keyof FeatureFlags;

--- a/src/lib/utils/feature-flags-edge.ts
+++ b/src/lib/utils/feature-flags-edge.ts
@@ -10,6 +10,7 @@ import { DEFAULT_FLAGS } from "./feature-flags";
  * - ENABLE_AUTHENTICATION (true/false)
  * - FF_Chat_Analysis_Screen (true/false)
  * - FF_FULL_PAGE_NAVIGATION (true/false)
+ * - FF_Modals (true/false)
  */
 export function loadFeatureFlagsEdge(): FeatureFlags {
   try {
@@ -17,6 +18,7 @@ export function loadFeatureFlagsEdge(): FeatureFlags {
       enableAuthentication: process.env.ENABLE_AUTHENTICATION !== "false",
       FF_Chat_Analysis_Screen: process.env.FF_Chat_Analysis_Screen !== "false",
       FF_Full_Page_Navigation: process.env.FF_FULL_PAGE_NAVIGATION !== "false",
+      FF_Modals: process.env.FF_Modals !== "false",
     };
   } catch (error) {
     console.warn(

--- a/src/lib/utils/feature-flags.ts
+++ b/src/lib/utils/feature-flags.ts
@@ -5,6 +5,7 @@ export const DEFAULT_FLAGS: FeatureFlags = {
   enableAuthentication: true,
   FF_Chat_Analysis_Screen: true,
   FF_Full_Page_Navigation: true,
+  FF_Modals: true,
 };
 
 /**
@@ -51,6 +52,7 @@ const loadFromEnvironment = (): FeatureFlags => {
   let enableAuth = DEFAULT_FLAGS.enableAuthentication;
   const FF_Chat_Analysis_Screen = DEFAULT_FLAGS.FF_Chat_Analysis_Screen;
   let FF_Full_Page_Navigation = DEFAULT_FLAGS.FF_Full_Page_Navigation;
+  const FF_Modals = DEFAULT_FLAGS.FF_Modals;
 
   if (process.env.FEATURE_FLAG_ENABLE_AUTHENTICATION !== undefined) {
     enableAuth =
@@ -66,6 +68,7 @@ const loadFromEnvironment = (): FeatureFlags => {
     enableAuthentication: enableAuth,
     FF_Chat_Analysis_Screen: FF_Chat_Analysis_Screen,
     FF_Full_Page_Navigation: FF_Full_Page_Navigation,
+    FF_Modals: FF_Modals,
   };
 
   return flags;


### PR DESCRIPTION
- Introduced FF_Modals feature flag in feature-flags configuration.
- Updated jest.setup.ts to mock FF_Modals in feature flags API responses.
- Enhanced tests across various components and hooks to include FF_Modals, ensuring consistent behavior.
- Refactored modals to utilize FeatureFlaggedDialog for conditional rendering based on feature flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new feature flag, "FF_Modals", to control modal-related functionality.
  * Added a new FeatureFlaggedDialog component that conditionally displays dialogs based on the "FF_Modals" flag.

* **Enhancements**
  * Updated ConfirmationModal and RawDataModal components to use the new FeatureFlaggedDialog for feature flag support.

* **Bug Fixes**
  * Ensured consistent handling of feature flags in both client and edge environments.

* **Tests**
  * Added and updated test suites to cover the new feature flag and FeatureFlaggedDialog component behavior.

* **Chores**
  * Updated configuration, environment loading, and setup files to support the new feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->