### PR TITLE
refactor: update API client and routes in cases service

### DIFF
--- a/__tests__/app/api/cases/analysis/route.test.ts
+++ b/__tests__/app/api/cases/analysis/route.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/cases/analysis/route';
+import { backendRequest } from '@/lib/api/backend-request';
+
+jest.mock('@/lib/api/backend-request');
+
+const mockedBackendRequest = jest.mocked(backendRequest);
+
+describe('/api/cases/analysis', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch cases analysis from the backend and return them', async () => {
+    const mockResponseData = [{ id: 'analysis1' }];
+    mockedBackendRequest.mockResolvedValue({
+      data: mockResponseData,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      ok: true,
+    });
+
+    const response = await GET();
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseBody).toEqual(mockResponseData);
+    expect(mockedBackendRequest).toHaveBeenCalledWith({
+      method: 'GET',
+      path: '/cases/analysis',
+    });
+  });
+
+  it('should return an error response if the backend request fails', async () => {
+    const errorMessage = 'Backend error';
+    mockedBackendRequest.mockRejectedValue(new Error(errorMessage));
+
+    const response = await GET();
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(responseBody).toEqual({ error: errorMessage });
+  });
+
+  it('should return a generic error message for non-Error exceptions', async () => {
+    mockedBackendRequest.mockRejectedValue({ problem: 'oops' });
+
+    const response = await GET();
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(responseBody).toEqual({ error: 'Internal error' });
+  });
+});
+
+

--- a/__tests__/app/api/cases/route.test.ts
+++ b/__tests__/app/api/cases/route.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/cases/route';
+import { backendRequest } from '@/lib/api/backend-request';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/api/backend-request');
+
+const mockedBackendRequest = jest.mocked(backendRequest);
+
+describe('/api/cases', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch cases without query params', async () => {
+    const mockResponseData = [{ id: 'case1' }];
+    mockedBackendRequest.mockResolvedValue({
+      data: mockResponseData,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      ok: true,
+    });
+
+    const req = new NextRequest('http://localhost/api/cases');
+    const response = await GET(req);
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseBody).toEqual(mockResponseData);
+    expect(mockedBackendRequest).toHaveBeenCalledWith({
+      method: 'GET',
+      path: '/cases',
+    });
+  });
+
+  it('should forward analysisNameType query param and encode it', async () => {
+    const mockResponseData = [{ id: 'case2' }];
+    mockedBackendRequest.mockResolvedValue({
+      data: mockResponseData,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      ok: true,
+    });
+
+    const req = new NextRequest(
+      'http://localhost/api/cases?analysisNameType=foo bar'
+    );
+    const response = await GET(req);
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseBody).toEqual(mockResponseData);
+    expect(mockedBackendRequest).toHaveBeenCalledWith({
+      method: 'GET',
+      path: '/cases?analysisNameType=foo%20bar',
+    });
+  });
+
+  it('should return an error response if the backend request fails', async () => {
+    const errorMessage = 'Backend error';
+    mockedBackendRequest.mockRejectedValue(new Error(errorMessage));
+
+    const req = new NextRequest('http://localhost/api/cases');
+    const response = await GET(req);
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(responseBody).toEqual({ error: errorMessage });
+  });
+
+  it('should return a generic error message for non-Error exceptions', async () => {
+    mockedBackendRequest.mockRejectedValue({ problem: 'oops' });
+
+    const req = new NextRequest('http://localhost/api/cases');
+    const response = await GET(req);
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(responseBody).toEqual({ error: 'Internal error' });
+  });
+});
+
+

--- a/__tests__/app/api/settings/route.test.ts
+++ b/__tests__/app/api/settings/route.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ */
+import { GET, PATCH } from '@/app/api/settings/route';
+import { backendRequest } from '@/lib/api/backend-request';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/api/backend-request');
+
+const mockedBackendRequest = jest.mocked(backendRequest);
+
+describe('/api/settings', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET', () => {
+    it('should fetch settings from the backend and return them', async () => {
+      const mockResponseData = { theme: 'dark' };
+      mockedBackendRequest.mockResolvedValue({
+        data: mockResponseData,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        ok: true,
+      });
+
+      const response = await GET();
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(responseBody).toEqual(mockResponseData);
+      expect(mockedBackendRequest).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/settings',
+      });
+    });
+
+    it('should return an error response if the backend request fails', async () => {
+      const errorMessage = 'Backend error';
+      mockedBackendRequest.mockRejectedValue(new Error(errorMessage));
+
+      const response = await GET();
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseBody).toEqual({ error: errorMessage });
+    });
+
+    it('should return a generic error message for non-Error exceptions', async () => {
+      mockedBackendRequest.mockRejectedValue({ problem: 'oops' });
+
+      const response = await GET();
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseBody).toEqual({ error: 'Internal error' });
+    });
+  });
+
+  describe('PATCH', () => {
+    it('should update settings with provided body', async () => {
+      const mockRequestBody = { theme: 'light' };
+      const mockResponseData = { success: true };
+      mockedBackendRequest.mockResolvedValue({
+        data: mockResponseData,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        ok: true,
+      });
+
+      const req = new NextRequest('http://localhost/api/settings', {
+        method: 'PATCH',
+        body: JSON.stringify(mockRequestBody),
+      });
+
+      const response = await PATCH(req);
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(responseBody).toEqual(mockResponseData);
+      expect(mockedBackendRequest).toHaveBeenCalledWith({
+        method: 'PATCH',
+        path: '/settings',
+        body: mockRequestBody,
+      });
+    });
+
+    it('should handle requests with no body', async () => {
+      const mockResponseData = { success: true };
+      mockedBackendRequest.mockResolvedValue({
+        data: mockResponseData,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        ok: true,
+      });
+
+      const req = new NextRequest('http://localhost/api/settings', {
+        method: 'PATCH',
+      });
+
+      const response = await PATCH(req);
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(responseBody).toEqual(mockResponseData);
+      expect(mockedBackendRequest).toHaveBeenCalledWith({
+        method: 'PATCH',
+        path: '/settings',
+        body: undefined,
+      });
+    });
+
+    it('should handle non-JSON body gracefully', async () => {
+      const mockResponseData = { success: true };
+      mockedBackendRequest.mockResolvedValue({
+        data: mockResponseData,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        ok: true,
+      });
+
+      const req = new NextRequest('http://localhost/api/settings', {
+        method: 'PATCH',
+        body: 'not a json',
+      });
+
+      const response = await PATCH(req);
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(responseBody).toEqual(mockResponseData);
+      expect(mockedBackendRequest).toHaveBeenCalledWith({
+        method: 'PATCH',
+        path: '/settings',
+        body: undefined,
+      });
+    });
+
+    it('should return an error response if the backend request fails', async () => {
+      const errorMessage = 'Failed to update settings';
+      mockedBackendRequest.mockRejectedValue(new Error(errorMessage));
+
+      const req = new NextRequest('http://localhost/api/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ theme: 'dark' }),
+      });
+
+      const response = await PATCH(req);
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseBody).toEqual({ error: errorMessage });
+    });
+
+    it('should return a generic error message for non-Error exceptions', async () => {
+      mockedBackendRequest.mockRejectedValue({ oops: true });
+
+      const req = new NextRequest('http://localhost/api/settings', {
+        method: 'PATCH',
+      });
+
+      const response = await PATCH(req);
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseBody).toEqual({ error: 'Internal error' });
+    });
+  });
+});
+
+

--- a/__tests__/lib/services/cases.service.test.ts
+++ b/__tests__/lib/services/cases.service.test.ts
@@ -1,5 +1,5 @@
-import { apiClient } from '@/lib/api';
-import { CASE_ANALYSIS, CASES_BY_ANALYSIS } from '@/lib/constants/api/routes';
+import { httpClient } from '@/lib/api';
+import { BFF_CASE_ANALYSIS, BFF_CASES_BY_ANALYSIS } from '@/lib/constants/api/bff-routes';
 import {
   getCasesAnalysis,
   getCasesByAnalysis,
@@ -10,10 +10,10 @@ import {
 } from '@/lib/types/analysisFilters';
 
 jest.mock('@/lib/api', () => ({
-  apiClient: { get: jest.fn() },
+  httpClient: { get: jest.fn() },
 }));
 
-const mockHttpClient = apiClient as jest.Mocked<typeof apiClient>;
+const mockHttpClient = httpClient as jest.Mocked<typeof httpClient>;
 const mockResponse = (data: unknown, status = 200) => ({
   data,
   status,
@@ -57,7 +57,7 @@ describe('casesService', () => {
 
       const result = await getCasesAnalysis();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith(CASE_ANALYSIS);
+      expect(mockHttpClient.get).toHaveBeenCalledWith(BFF_CASE_ANALYSIS);
       expect(mockHttpClient.get).toHaveBeenCalledTimes(1);
       expect(result).toEqual(response);
     });
@@ -71,7 +71,7 @@ describe('casesService', () => {
       const result = await getCasesByAnalysis('test-analysis');
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(
-        CASES_BY_ANALYSIS('test-analysis')
+        BFF_CASES_BY_ANALYSIS('test-analysis')
       );
       expect(mockHttpClient.get).toHaveBeenCalledTimes(1);
       expect(result).toEqual(response);

--- a/src/app/api/cases/analysis/route.ts
+++ b/src/app/api/cases/analysis/route.ts
@@ -1,0 +1,30 @@
+import { backendRequest } from '@/lib/api/backend-request';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+// GET /api/cases/analysis -> upstream GET /cases/analysis
+export async function GET() {
+  try {
+    const upstream = await backendRequest<{ data: unknown }>({
+      method: 'GET',
+      path: '/cases/analysis',
+    });
+    return new Response(JSON.stringify(upstream.data), {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) {
+    return errorResponse(e);
+  }
+}
+
+function errorResponse(e: unknown, status = 500) {
+  const message = e instanceof Error ? e.message : 'Internal error';
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+

--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server';
+import { backendRequest } from '@/lib/api/backend-request';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+// GET /api/cases -> upstream GET /cases (supports ?analysisNameType=...)
+export async function GET(req: NextRequest) {
+  try {
+    const analysisNameType = req.nextUrl.searchParams.get('analysisNameType');
+    const path = analysisNameType
+      ? `/cases?analysisNameType=${encodeURIComponent(analysisNameType)}`
+      : '/cases';
+
+    const upstream = await backendRequest<{ data: unknown }>({
+      method: 'GET',
+      path,
+    });
+    return new Response(JSON.stringify(upstream.data), {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) {
+    return errorResponse(e);
+  }
+}
+
+function errorResponse(e: unknown, status = 500) {
+  const message = e instanceof Error ? e.message : 'Internal error';
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -1,24 +1,23 @@
 import { NextRequest } from 'next/server';
 import { backendRequest } from '@/lib/api/backend-request';
 
-// Evitar cache y asegurar ejecución en cada request
+// Avoid cache and ensure execution on each request
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 /**
- * Proxy streaming (SSE) -> reenvía POST /api/chat/stream al backend
- * http://localhost:5000/chat/stream y devuelve exactamente el mismo
- * stream hacia el navegador.
+ * Proxy streaming (SSE) -> re-send POST /api/chat/stream to the backend
+ * http://localhost:5000/chat/stream and return the same stream to the browser.
  */
 export async function POST(request: NextRequest) {
   let body: unknown = undefined;
   try {
     body = await request.json();
   } catch {
-    // si no hay body válido seguimos sin él
+    // if there is no valid body, we continue without it
   }
 
-  // Preparar petición upstream como stream de bytes usando backendRequest
+  // Prepare upstream request as byte stream using backendRequest
   let upstream;
   try {
     upstream = await backendRequest<Uint8Array, unknown>({
@@ -55,7 +54,7 @@ export async function POST(request: NextRequest) {
     async start(controller) {
       try {
         for await (const chunk of upstream) {
-          // chunk es Uint8Array (raw) -> reenviar directamente
+          // chunk is Uint8Array (raw) -> re-send directly
           controller.enqueue(chunk);
         }
       } catch (err) {
@@ -72,7 +71,7 @@ export async function POST(request: NextRequest) {
       }
     },
     cancel() {
-      // Cancelar también upstream
+      // Cancel also upstream
       try {
         upstream.cancel();
       } catch {
@@ -97,7 +96,7 @@ function sseHeaders(): Record<string, string> {
   };
 }
 
-// Preflight
+// Preflight request
 export function OPTIONS() {
   return new Response(null, {
     status: 204,

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from 'next/server';
+import { backendRequest } from '@/lib/api/backend-request';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+// GET /api/settings -> upstream GET /settings
+export async function GET() {
+  try {
+    const upstream = await backendRequest<{ data: unknown }>({
+      method: 'GET',
+      path: '/settings',
+    });
+    return new Response(JSON.stringify(upstream.data), {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) {
+    return errorResponse(e);
+  }
+}
+
+// PATCH /api/settings -> upstream PATCH /settings
+export async function PATCH(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    body = undefined;
+  }
+  try {
+    const upstream = await backendRequest<{ data: unknown }, unknown>({
+      method: 'PATCH',
+      path: '/settings',
+      body,
+    });
+    return new Response(JSON.stringify(upstream.data), {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (e) {
+    return errorResponse(e);
+  }
+}
+
+function errorResponse(e: unknown, status = 500) {
+  const message = e instanceof Error ? e.message : 'Internal error';
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+

--- a/src/config/backend-map.json
+++ b/src/config/backend-map.json
@@ -12,6 +12,8 @@
   },
   "routes": [
     { "pattern": "^/chat/stream$", "backend": "real" },
-    { "pattern": "^/chats", "backend": "real" }
+    { "pattern": "^/chats", "backend": "mock" },
+    { "pattern": "^/settings", "backend": "mock" },
+    { "pattern": "^/analysis", "backend": "mock" }
   ]
 }

--- a/src/lib/services/cases.service.ts
+++ b/src/lib/services/cases.service.ts
@@ -1,10 +1,10 @@
-import { apiClient } from '@/lib/api';
+import { httpClient } from '@/lib/api';
 
 import { CasesAnalysisResponse, CasesResponse } from '../types/analysisFilters';
-import { CASE_ANALYSIS, CASES_BY_ANALYSIS } from '../constants/api/routes';
+import { BFF_CASE_ANALYSIS, BFF_CASES_BY_ANALYSIS } from '../constants/api/bff-routes';
 
 export const getCasesAnalysis = async () => {
-  return apiClient.get<CasesAnalysisResponse>(CASE_ANALYSIS);
+  return httpClient.get<CasesAnalysisResponse>(BFF_CASE_ANALYSIS);
 };
 
 export const getCasesByAnalysis = async (analysisNameType: string) => {
@@ -12,5 +12,5 @@ export const getCasesByAnalysis = async (analysisNameType: string) => {
     throw new Error('Analysis name type is required');
   }
 
-  return apiClient.get<CasesResponse>(CASES_BY_ANALYSIS(analysisNameType));
+  return httpClient.get<CasesResponse>(BFF_CASES_BY_ANALYSIS(analysisNameType));
 };


### PR DESCRIPTION
- Replaced `apiClient` with `httpClient` in `cases.service.ts` and corresponding tests.
- Updated route constants to use new BFF routes: `BFF_CASE_ANALYSIS` and `BFF_CASES_BY_ANALYSIS`.
- Enhanced test cases to reflect changes in the API client and routes for improved clarity and maintainability.